### PR TITLE
Docker --build-args for php extensions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -y \
 
 RUN if [ "$phpext" != "" ]; then \
     for item in $phpext; do \
-        ocker-php-ext-install $item; \
+        docker-php-ext-install $item; \
     done;\
     fi;
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM php:fpm
 MAINTAINER finkel <sergio.kudrin@gmail.com>
 
+ARG phpext
+
 RUN apt-get update && apt-get install -y \
         libmcrypt-dev \
         libfreetype6-dev \
@@ -10,10 +12,17 @@ RUN apt-get update && apt-get install -y \
         && apt-get install -y zlib1g-dev libicu-dev g++ \
         && docker-php-ext-install -j$(nproc) iconv mcrypt \
         && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-        && docker-php-ext-install -j$(nproc) gd
-RUN docker-php-ext-install mbstring
-RUN docker-php-ext-install exif
-RUN docker-php-ext-install opcache
+        && docker-php-ext-install -j$(nproc) gd \
+        && docker-php-ext-install mbstring \
+        && docker-php-ext-install exif \
+        && docker-php-ext-install opcache
+
+RUN if [ "$phpext" != "" ]; then \
+    for item in $phpext; do \
+        ocker-php-ext-install $item; \
+    done;\
+    fi;
+
 RUN curl -sS -o /tmp/icu.tar.gz -L http://download.icu-project.org/files/icu4c/58.1/icu4c-58_1-src.tgz && tar -zxf /tmp/icu.tar.gz -C /tmp && cd /tmp/icu/source && ./configure --prefix=/usr/local && make && make install
 RUN docker-php-ext-configure intl --with-icu-dir=/usr/local && \
     docker-php-ext-install intl


### PR DESCRIPTION
To use additional extensions you need to use --build-arg

For example:
sudo docker build --build-arg phpext="pcntl pdo_mysql" .